### PR TITLE
FIXED: fixed Strikethrough appearing in preview of document

### DIFF
--- a/css/gerador.css
+++ b/css/gerador.css
@@ -466,14 +466,14 @@ label[for^="accstmnt_assessment_with_users"], label[for^="accstmnt_orginfo_conta
 .remove-line{
 	color: #8e0d0d;
 }
-
+/*
 .discard {
   all: initial;
   * {
     all: unset;
 	}
 }
-.discard h1, .discard h2, .discard h3 {
+	*/.discard h1, .discard h2, .discard h3 {
 	display: block;
     margin-block-start: 0.83em;
     margin-block-end: 0.83em;

--- a/en/index.html
+++ b/en/index.html
@@ -2044,10 +2044,12 @@
 											<div data-if="accstmnt_assessment_additional_evidence_data">
 											  <h3>Other evidences</h3>
 											  <span class="mr mr-seal-other">
+												<p>
 												<span
 												  id="accstmnt_additional_evidence_summary"
 												  data-print="accstmnt_assessment_additional_evidence_data"
 												></span>
+												</p>
 											  </span>
 											</div>
 										</div>

--- a/index.html
+++ b/index.html
@@ -1977,10 +1977,12 @@
 											<div data-if="accstmnt_assessment_additional_evidence_data">
 											  <h3>Outras evidências</h3>
 											  <span class="mr mr-seal-other">
+												<p>
 												<span
 												  id="accstmnt_additional_evidence_summary"
 												  data-print="accstmnt_assessment_additional_evidence_data"
 												></span>
+												</p>
 											  </span>
 											</div>
 										</div>


### PR DESCRIPTION
Fixed strikethrough on text in document preview caused by a css reset rule in css/gerador.css
